### PR TITLE
Explicitly delete artefacts in `DeleteMachine` function and do not rely on garbage collection

### DIFF
--- a/pkg/local/create_machine.go
+++ b/pkg/local/create_machine.go
@@ -80,94 +80,85 @@ func (d *localDriver) applyPod(ctx context.Context, req *driver.CreateMachineReq
 		return nil, status.Error(codes.Internal, fmt.Sprintf("error applying user data secret: %s", err.Error()))
 	}
 
-	pod := &corev1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: corev1.SchemeGroupVersion.String(),
-			Kind:       "Pod",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      podName(req.Machine.Name),
-			Namespace: req.Machine.Namespace,
-			Labels: map[string]string{
-				labelKeyProvider: apiv1alpha1.Provider,
-				labelKeyApp:      labelValueMachine,
-				"networking.gardener.cloud/from-prometheus":      "allowed",
-				"networking.gardener.cloud/to-dns":               "allowed",
-				"networking.gardener.cloud/to-private-networks":  "allowed",
-				"networking.gardener.cloud/to-public-networks":   "allowed",
-				"networking.gardener.cloud/to-shoot-networks":    "allowed",
-				"networking.gardener.cloud/to-shoot-apiserver":   "allowed",
-				"networking.gardener.cloud/from-shoot-apiserver": "allowed",
+	pod := podForMachine(req.Machine)
+	pod.Labels = map[string]string{
+		labelKeyProvider: apiv1alpha1.Provider,
+		labelKeyApp:      labelValueMachine,
+		"networking.gardener.cloud/from-prometheus":      "allowed",
+		"networking.gardener.cloud/to-dns":               "allowed",
+		"networking.gardener.cloud/to-private-networks":  "allowed",
+		"networking.gardener.cloud/to-public-networks":   "allowed",
+		"networking.gardener.cloud/to-shoot-networks":    "allowed",
+		"networking.gardener.cloud/to-shoot-apiserver":   "allowed",
+		"networking.gardener.cloud/from-shoot-apiserver": "allowed",
+	}
+	pod.Spec = corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:            "node",
+				Image:           providerSpec.Image,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				SecurityContext: &corev1.SecurityContext{
+					Privileged: pointer.Bool(true),
+				},
+				Env: []corev1.EnvVar{{
+					Name: "NODE_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				}},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "userdata",
+						MountPath: "/etc/machine",
+					},
+					{
+						Name:      "containerd",
+						MountPath: "/var/lib/containerd",
+					},
+					{
+						Name:      "modules",
+						MountPath: "/lib/modules",
+						ReadOnly:  true,
+					},
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{
+							Command: []string{"sh", "-c", "/opt/bin/kubectl --kubeconfig /var/lib/kubelet/kubeconfig-real get no $NODE_NAME"},
+						},
+					},
+				},
+				Ports: []corev1.ContainerPort{{
+					ContainerPort: 30123,
+					Name:          "vpn-shoot",
+					Protocol:      corev1.ProtocolTCP,
+				}},
 			},
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:            "node",
-					Image:           providerSpec.Image,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: pointer.Bool(true),
+		Volumes: []corev1.Volume{
+			{
+				Name: "userdata",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName:  userDataSecret.Name,
+						DefaultMode: pointer.Int32(0777),
 					},
-					Env: []corev1.EnvVar{{
-						Name: "NODE_NAME",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.name",
-							},
-						},
-					}},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "userdata",
-							MountPath: "/etc/machine",
-						},
-						{
-							Name:      "containerd",
-							MountPath: "/var/lib/containerd",
-						},
-						{
-							Name:      "modules",
-							MountPath: "/lib/modules",
-							ReadOnly:  true,
-						},
-					},
-					ReadinessProbe: &corev1.Probe{
-						ProbeHandler: corev1.ProbeHandler{
-							Exec: &corev1.ExecAction{
-								Command: []string{"sh", "-c", "/opt/bin/kubectl --kubeconfig /var/lib/kubelet/kubeconfig-real get no $NODE_NAME"},
-							},
-						},
-					},
-					Ports: []corev1.ContainerPort{{
-						ContainerPort: 30123,
-						Name:          "vpn-shoot",
-						Protocol:      corev1.ProtocolTCP,
-					}},
 				},
 			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "userdata",
-					VolumeSource: corev1.VolumeSource{
-						Secret: &corev1.SecretVolumeSource{
-							SecretName:  userDataSecret.Name,
-							DefaultMode: pointer.Int32(0777),
-						},
-					},
+			{
+				Name: "containerd",
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
 				},
-				{
-					Name: "containerd",
-					VolumeSource: corev1.VolumeSource{
-						EmptyDir: &corev1.EmptyDirVolumeSource{},
-					},
-				},
-				{
-					Name: "modules",
-					VolumeSource: corev1.VolumeSource{
-						HostPath: &corev1.HostPathVolumeSource{
-							Path: "/lib/modules",
-						},
+			},
+			{
+				Name: "modules",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/lib/modules",
 					},
 				},
 			},

--- a/pkg/local/delete_machine.go
+++ b/pkg/local/delete_machine.go
@@ -38,6 +38,12 @@ func (d *localDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachi
 	klog.V(3).Infof("Machine deletion request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
 
+	userDataSecret := userDataSecretForMachine(req.Machine)
+	if err := d.client.Delete(ctx, userDataSecret); client.IgnoreNotFound(err) != nil {
+		// Unknown leads to short retry in machine controller
+		return nil, status.Error(codes.Unknown, fmt.Sprintf("error deleting user data secret: %s", err.Error()))
+	}
+
 	pod := podForMachine(req.Machine)
 	if err := d.client.Delete(ctx, pod); err != nil {
 		if !apierrors.IsNotFound(err) {

--- a/pkg/local/delete_machine.go
+++ b/pkg/local/delete_machine.go
@@ -17,13 +17,17 @@ package local
 import (
 	"context"
 	"fmt"
+	"time"
 
 	apiv1alpha1 "github.com/gardener/machine-controller-manager-provider-local/pkg/api/v1alpha1"
+
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
-
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (d *localDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachineRequest) (*driver.DeleteMachineResponse, error) {
@@ -34,9 +38,34 @@ func (d *localDriver) DeleteMachine(ctx context.Context, req *driver.DeleteMachi
 	klog.V(3).Infof("Machine deletion request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine deletion request has been processed for %q", req.Machine.Name)
 
-	// Nothing to do here since the Pod and user data Secret were created with an owner reference pointing to the
-	// Machine object.
-	// Consequently, the Pod and the Secret are auto-deleted when the Machine object gets deleted.
+	pod := podForMachine(req.Machine)
+	if err := d.client.Delete(ctx, pod); err != nil {
+		if !apierrors.IsNotFound(err) {
+			// Unknown leads to short retry in machine controller
+			return nil, status.Error(codes.Unknown, fmt.Sprintf("error deleting pod: %s", err.Error()))
+		}
+		return nil, status.Error(codes.NotFound, err.Error())
+	}
+
+	// Actively wait until pod is deleted since the extension contract in machine-controller-manager expects drivers to
+	// do so. If we would not wait until the pod is gone it might happen that the kubelet could re-register the Node
+	// object even after it was already deleted by machine-controller-manager.
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+
+	if err := wait.PollUntilWithContext(timeoutCtx, 5*time.Second, func(ctx context.Context) (bool, error) {
+		if err := d.client.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			// Unknown leads to short retry in machine controller
+			return false, status.Error(codes.Unknown, err.Error())
+		}
+		return false, nil
+	}); err != nil {
+		// will be retried with short retry by machine controller
+		return nil, status.Error(codes.DeadlineExceeded, err.Error())
+	}
 
 	return &driver.DeleteMachineResponse{}, nil
 }

--- a/pkg/local/driver.go
+++ b/pkg/local/driver.go
@@ -17,7 +17,10 @@ package local
 import (
 	"context"
 
+	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -40,6 +43,19 @@ type localDriver struct {
 // GenerateMachineClassForMigration is not implemented.
 func (d *localDriver) GenerateMachineClassForMigration(_ context.Context, _ *driver.GenerateMachineClassForMigrationRequest) (*driver.GenerateMachineClassForMigrationResponse, error) {
 	return &driver.GenerateMachineClassForMigrationResponse{}, nil
+}
+
+func podForMachine(machine *machinev1alpha1.Machine) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName(machine.Name),
+			Namespace: machine.Namespace,
+		},
+	}
 }
 
 func podName(machineName string) string {

--- a/pkg/local/driver.go
+++ b/pkg/local/driver.go
@@ -58,10 +58,19 @@ func podForMachine(machine *machinev1alpha1.Machine) *corev1.Pod {
 	}
 }
 
-func podName(machineName string) string {
-	return "machine-" + machineName
+func userDataSecretForMachine(machine *machinev1alpha1.Machine) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName(machine.Name) + "-userdata",
+			Namespace: machine.Namespace,
+		},
+	}
 }
 
-func userDataSecretName(machineName string) string {
-	return podName(machineName) + "-userdata"
+func podName(machineName string) string {
+	return "machine-" + machineName
 }

--- a/pkg/local/get_machine_status.go
+++ b/pkg/local/get_machine_status.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/driver"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
-	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,8 +36,8 @@ func (d *localDriver) GetMachineStatus(ctx context.Context, req *driver.GetMachi
 	klog.V(3).Infof("Machine status request has been received for %q", req.Machine.Name)
 	defer klog.V(3).Infof("Machine status request has been processed for %q", req.Machine.Name)
 
-	pod := &corev1.Pod{}
-	if err := d.client.Get(ctx, client.ObjectKey{Name: req.Machine.Name, Namespace: req.Machine.Namespace}, pod); err != nil {
+	pod := podForMachine(req.Machine)
+	if err := d.client.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, status.Error(codes.NotFound, err.Error())
 		}


### PR DESCRIPTION
Otherwise, the `Machine` object might already disappear from the system while the "backing VM" (aka the `Pod`) still exists. This can lead to interesting situations (e.g. we saw that the `Node` of a deleted machine was re-registered after deletion).

Related to https://github.com/gardener/gardener/issues/5895