### PR TITLE
Bump `kindest/node` to `v1.21.12`

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM kindest/node:v1.21.1
+FROM kindest/node:v1.21.12
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kindest/node to v1.21.12. This implicitly upgrades the `containerd` version which itself upgrades the version of the `github.com/imdario/mergo` dependency which fixes https://github.com/imdario/mergo/issues/90 which is required to properly import additional `containerd` configuration.
