### PR TITLE
Bump kindest/node to v1.21.14

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM kindest/node:v1.21.12
+FROM kindest/node:v1.21.14
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kindest/node to v1.21.14

This updates the base image to ubuntu 22.04, which allows to install additional packages. Previously ubuntu 21.10 was used, which does not provide packages anymore as it is out of support.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
With the new release, `apt update` or `apt install <your-favorite-package>` will work again.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Use ubuntu LTS 22.04 as base image for kindest/node.
```
