### PR TITLE
Revert to node:v1.21.12

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM kindest/node:v1.21.14
+FROM kindest/node:v1.21.12
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
**What this PR does / why we need it**:
Revert to node:v1.21.12 as nodes did not get ready after https://github.com/gardener/machine-controller-manager-provider-local/pull/13.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
