### PR TITLE
Workaround new runc version causing problems.

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -28,4 +28,11 @@ COPY run-userdata.sh /run-userdata.sh
 COPY run-userdata.service /etc/systemd/system
 RUN systemctl enable run-userdata.service
 
+# workaround issue with runc v1.1.3/4 provided by kindest/node:v1.21.14 by installing runc v1.1.2 manually
+RUN echo "Installing runc v1.1.2 ..." \
+    && curl -sSL --retry 5 --output /tmp/runc.${TARGETARCH} "https://github.com/kind-ci/containerd-nightlies/releases/download/containerd-1.6.6/runc.${TARGETARCH}" \
+    && mv /tmp/runc.${TARGETARCH} /usr/local/sbin/runc \
+    && chmod 755 /usr/local/sbin/runc \
+    && runc --version
+
 ENTRYPOINT ["/usr/local/bin/entrypoint", "/sbin/init"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Workaround new runc version causing problems.

Unfortunately, runc in versions 1.1.3/1.1.4 has an issue causing container-in-container scenarios to fail with weird error messages (see https://github.com/opencontainers/runc/pull/3620 for details). This change installs runc v1.1.2 for the time being to mitigate the issue, i.e. let the nodes become ready again.

The code is freely adapted from https://github.com/kubernetes-sigs/kind/blob/v0.17.0/images/base/Dockerfile.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
