### PR TITLE
Update to `kindest/node@v1.24.12`

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM kindest/node:v1.21.14
+FROM kindest/node:v1.24.12
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -10,7 +10,7 @@ RUN apt-get update -yq && \
 # see https://github.com/gardener/gardener/issues/4673
 # Install nerdctl as a (mostly) docker-compatible replacement and fool the cloud-config-downloader with a small wrapper
 # this is quite hacky but relieves us from installing docker here
-ARG NERDCTL_VERSION=0.13.0
+ARG NERDCTL_VERSION=1.2.1
 RUN curl -Lo /tmp/nerdctl.tar.gz https://github.com/containerd/nerdctl/releases/download/v$NERDCTL_VERSION/nerdctl-$NERDCTL_VERSION-$TARGETOS-$TARGETARCH.tar.gz && \
     tar Cxzvvf /usr/local/bin /tmp/nerdctl.tar.gz && \
     rm -f /tmp/nerdctl.tar.gz
@@ -27,12 +27,5 @@ RUN rm -f /etc/systemd/system/kubelet.service && \
 COPY run-userdata.sh /run-userdata.sh
 COPY run-userdata.service /etc/systemd/system
 RUN systemctl enable run-userdata.service
-
-# workaround issue with runc v1.1.3/4 provided by kindest/node:v1.21.14 by installing runc v1.1.2 manually
-RUN echo "Installing runc v1.1.2 ..." \
-    && curl -sSL --retry 5 --output /tmp/runc.${TARGETARCH} "https://github.com/kind-ci/containerd-nightlies/releases/download/containerd-1.6.6/runc.${TARGETARCH}" \
-    && mv /tmp/runc.${TARGETARCH} /usr/local/sbin/runc \
-    && chmod 755 /usr/local/sbin/runc \
-    && runc --version
 
 ENTRYPOINT ["/usr/local/bin/entrypoint", "/sbin/init"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the kindest/node base image to version `v1.24.12` which sets `systemd` as `cgroupDriver`.

Alongside, it updates to `nerdctl@1.2.1`.

The workaround for runc which has been introduced in #15 is not needed anymore. 
`kindest/node@1.24.12` is based on [kind@v0.18.0](https://github.com/kubernetes-sigs/kind/releases/tag/v0.18.0) which uses [runc@v1.1.5](https://github.com/opencontainers/runc/releases/tag/v1.1.5). The `/dev/null` issue is solved in `runc@v1.1.5`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6016

**Special notes for your reviewer**:
https://github.com/gardener/gardener/pull/7797 and PRs for cherry-picks to release branches should be merged before.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Updates the kindest/node base image to version `v1.24.12` which sets `systemd` as `cgroupDriver`.
```
