### PR TITLE
Update to `kindest/node@v1.28.0`

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM kindest/node:v1.24.12
+FROM kindest/node:v1.28.0
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -10,7 +10,7 @@ RUN apt-get update -yq && \
 # see https://github.com/gardener/gardener/issues/4673
 # Install nerdctl as a (mostly) docker-compatible replacement and fool the cloud-config-downloader with a small wrapper
 # this is quite hacky but relieves us from installing docker here
-ARG NERDCTL_VERSION=1.2.1
+ARG NERDCTL_VERSION=1.6.0
 RUN curl -Lo /tmp/nerdctl.tar.gz https://github.com/containerd/nerdctl/releases/download/v$NERDCTL_VERSION/nerdctl-$NERDCTL_VERSION-$TARGETOS-$TARGETARCH.tar.gz && \
     tar Cxzvvf /usr/local/bin /tmp/nerdctl.tar.gz && \
     rm -f /tmp/nerdctl.tar.gz


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the kindest/node base image to version v1.28.0.

Additionally, it updates to nerdctl@1.6.0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The kindest/node base image is updated to version `v1.28.0`.
```
