### PR TITLE
Adapt machine readiness probe to node-agent

### DIFF
--- a/pkg/local/create_machine.go
+++ b/pkg/local/create_machine.go
@@ -150,7 +150,7 @@ func (d *localDriver) applyPod(
 				ReadinessProbe: &corev1.Probe{
 					ProbeHandler: corev1.ProbeHandler{
 						Exec: &corev1.ExecAction{
-							Command: []string{"sh", "-c", "/opt/bin/kubectl --kubeconfig /var/lib/kubelet/kubeconfig-real get no $NODE_NAME"},
+							Command: []string{"sh", "-c", "/usr/bin/kubectl --kubeconfig /var/lib/kubelet/kubeconfig-real get no $NODE_NAME"},
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Adapt machine readiness probe to node-agent.

Gardener node agent does not download kubectl anymore to /opt/bin/kubectl. Therefore, the readiness probe of machines in the local setup should no longer refer to this binary. Fortunately, the node image already comes with kubectl in /usr/bin/kubectl, which works for the readiness probe.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
After enabling gardener node agent in the local setup, all machines pods stay non-ready. This does not block creation/deletion of shoot clusters. It is not clear what the effect of it is, but it is safer to just use the correct binary.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Machines in the local setup work with gardener node agent and report proper readiness
```
