### PR TITLE
Enable `dependabot` for updating `Dockerfile`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Create PRs for images in Dockerfile
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables dependabot for updating images in Dockerfile similar to how [it is done in gardener/gardener](https://github.com/gardener/gardener/blob/master/.github/dependabot.yaml).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
