### PR TITLE
Enable `dependabot` for node images

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,3 +5,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+  # Create PRs for images in node/Dockerfile
+  - package-ecosystem: docker
+    directory: /node
+    schedule:
+      interval: daily


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables `dependabot` to update images in `node/Dockerfile`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
