### PR TITLE
Remove `charts` folder from `make generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ check: $(GOIMPORTS) $(GOLANGCI_LINT)
 
 .PHONY: generate
 generate: $(GOIMPORTS)
-	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/generate.sh ./charts/... ./cmd/... ./pkg/...
+	@$(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/generate.sh ./cmd/... ./pkg/...
 
 .PHONY: format
 format: $(GOIMPORTS)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes `charts` folder from `make generate` target because it does not exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @RaphaelVogel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
