### PR TITLE
Make IP pool names configurable in `MachineClass`

### DIFF
--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -6,6 +6,7 @@ metadata:
 provider: local
 providerSpec:
   image: timebertt/kind-node@sha256:2909ded4504ad3f03aad545e2046fca56bec4532023bc271295d03c04ef84dde
+  ipPoolName: default-ipv4-ippool
 secretRef:
   name: test-secret
   namespace: default

--- a/kubernetes/machine-class.yaml
+++ b/kubernetes/machine-class.yaml
@@ -6,7 +6,8 @@ metadata:
 provider: local
 providerSpec:
   image: timebertt/kind-node@sha256:2909ded4504ad3f03aad545e2046fca56bec4532023bc271295d03c04ef84dde
-  ipPoolName: default-ipv4-ippool
+  ipPoolNameV4: default-ipv4-ippool
+  # ipPoolNameV6: default-ipv6-ippool
 secretRef:
   name: test-secret
   namespace: default

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -17,6 +17,10 @@ type ProviderSpec struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Image is the container image to use for the node.
 	Image string `json:"image,omitempty"`
-	// IPPoolName is the name of the crd.projectcalico.org/v1.IPPool that should be used for machine pods.
-	IPPoolName string `json:"ipPoolName,omitempty"`
+	// IPPoolNameV4 is the name of the crd.projectcalico.org/v1.IPPool that should be used for machine pods for IPv4
+	// addresses.
+	IPPoolNameV4 string `json:"ipPoolNameV4,omitempty"`
+	// IPPoolNameV6 is the name of the crd.projectcalico.org/v1.IPPool that should be used for machine pods for IPv6
+	// addresses.
+	IPPoolNameV6 string `json:"ipPoolNameV6,omitempty"`
 }

--- a/pkg/api/v1alpha1/provider_spec.go
+++ b/pkg/api/v1alpha1/provider_spec.go
@@ -17,4 +17,6 @@ type ProviderSpec struct {
 	APIVersion string `json:"apiVersion,omitempty"`
 	// Image is the container image to use for the node.
 	Image string `json:"image,omitempty"`
+	// IPPoolName is the name of the crd.projectcalico.org/v1.IPPool that should be used for machine pods.
+	IPPoolName string `json:"ipPoolName,omitempty"`
 }

--- a/pkg/local/create_machine.go
+++ b/pkg/local/create_machine.go
@@ -69,9 +69,15 @@ func (d *localDriver) applyPod(
 	error,
 ) {
 	pod := podForMachine(req.Machine)
-	pod.Annotations = map[string]string{
-		"cni.projectcalico.org/ipv4pools": `["` + providerSpec.IPPoolName + `"]`,
+	pod.Annotations = map[string]string{}
+
+	if providerSpec.IPPoolNameV4 != "" {
+		pod.Annotations["cni.projectcalico.org/ipv4pools"] = `["` + providerSpec.IPPoolNameV4 + `"]`
 	}
+	if providerSpec.IPPoolNameV6 != "" {
+		pod.Annotations["cni.projectcalico.org/ipv6pools"] = `["` + providerSpec.IPPoolNameV6 + `"]`
+	}
+
 	pod.Labels = map[string]string{
 		labelKeyProvider:                   apiv1alpha1.Provider,
 		labelKeyApp:                        labelValueMachine,

--- a/pkg/local/create_machine.go
+++ b/pkg/local/create_machine.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/status"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
@@ -49,10 +48,6 @@ func (d *localDriver) CreateMachine(ctx context.Context, req *driver.CreateMachi
 		return nil, status.Error(codes.Internal, fmt.Sprintf("error applying user data secret: %s", err.Error()))
 	}
 
-	if _, err := d.applyService(ctx, req); err != nil {
-		return nil, err
-	}
-
 	pod, err := d.applyPod(ctx, req, providerSpec, userDataSecret)
 	if err != nil {
 		return nil, err
@@ -62,27 +57,6 @@ func (d *localDriver) CreateMachine(ctx context.Context, req *driver.CreateMachi
 		ProviderID: pod.Name,
 		NodeName:   pod.Name,
 	}, nil
-}
-
-func (d *localDriver) applyService(ctx context.Context, req *driver.CreateMachineRequest) (*corev1.Service, error) {
-	svc := service(req.Machine)
-	svc.Spec.Type = corev1.ServiceTypeClusterIP
-	svc.Spec.ClusterIP = corev1.ClusterIPNone
-	svc.Spec.Ports = []corev1.ServicePort{{
-		Port:       10250,
-		Protocol:   corev1.ProtocolTCP,
-		TargetPort: intstr.FromInt(10250),
-	}}
-	svc.Spec.Selector = map[string]string{
-		labelKeyProvider: apiv1alpha1.Provider,
-		labelKeyApp:      labelValueMachine,
-	}
-
-	if err := d.client.Patch(ctx, svc, client.Apply, fieldOwner, client.ForceOwnership); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("error applying service: %s", err.Error()))
-	}
-
-	return svc, nil
 }
 
 func (d *localDriver) applyPod(
@@ -95,13 +69,15 @@ func (d *localDriver) applyPod(
 	error,
 ) {
 	pod := podForMachine(req.Machine)
+	pod.Annotations = map[string]string{
+		"cni.projectcalico.org/ipv4pools": `["` + providerSpec.IPPoolName + `"]`,
+	}
 	pod.Labels = map[string]string{
 		labelKeyProvider:                   apiv1alpha1.Provider,
 		labelKeyApp:                        labelValueMachine,
 		"networking.gardener.cloud/to-dns": "allowed",
 		"networking.gardener.cloud/to-private-networks":                 "allowed",
 		"networking.gardener.cloud/to-public-networks":                  "allowed",
-		"networking.gardener.cloud/to-shoot-networks":                   "allowed",
 		"networking.gardener.cloud/to-runtime-apiserver":                "allowed", // needed for ManagedSeeds such that gardenlets deployed to these Machines can talk to the seed's kube-apiserver (which is the same like the garden cluster kube-apiserver)
 		"networking.resources.gardener.cloud/to-kube-apiserver-tcp-443": "allowed",
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes the name of the calico IP pools configurable via the `MachineClass`.

The `Service` is dropped because the respective `NetworkPolicy`s are no longer needed since no seed component should directly talk to the machine pods (communication should always happen via the VPN tunnel only).

The `to-shoot-networks` network policy label is dropped because `gardener/gardener` will drop the respective `NetworkPolicy` entirely (TODO: reference PR here).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9604

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
